### PR TITLE
Fix deprecation warning

### DIFF
--- a/autocurry/__init__.py
+++ b/autocurry/__init__.py
@@ -1,4 +1,5 @@
-from inspect import getargspec
+import inspect
+import sys
 
 __all__ = ['autocurry']
 
@@ -17,7 +18,14 @@ class autocurry(object):
         self.fkwargs.update(kwargs)
 
         # determine number of non-keyword args
-        arg_spec = getargspec(self.f)
+        # Python v3.5 reported getfullargspec as deprecated, but this was
+        # reversed in v3.6. For simplicity, we'll just do it the new way
+        # for everything but v3.5, which means the deprecation warning about
+        # getargspec will still show for v3.5
+        if sys.version_info[0] == 3 and sys.version_info[1] != 5:
+            arg_spec = inspect.getfullargspec(self.f)
+        else:
+            arg_spec = inspect.getargspec(self.f)
         num_args = len(arg_spec[0])
         num_args -= len(arg_spec[3]) if arg_spec[3] else 0  # subtract number of arguments which have default values
 


### PR DESCRIPTION
The comment is probably overkill, feel free to edit it down.
Quieting the warning in v3.5 would involve using the inspect.signature method, which would make the code significantly dirtier for what is such a simple need, so I chose to go the simple route.